### PR TITLE
mysql2に依存していないのでadd_development_dependencyに修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     nippo_core (0.1.0)
       active_decorator
       devise
-      mysql2
       pundit
       rails (~> 5.0.2)
       redcarpet
@@ -168,6 +167,7 @@ PLATFORMS
 
 DEPENDENCIES
   factory_girl_rails
+  mysql2
   nippo_core!
   rspec-rails
   shoulda-matchers

--- a/nippo_core.gemspec
+++ b/nippo_core.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '~> 5.0.2'
 
-  s.add_dependency 'mysql2'
   s.add_dependency 'slim-rails'
   s.add_dependency 'devise'
   s.add_dependency 'active_decorator'
   s.add_dependency 'redcarpet'
   s.add_dependency 'pundit'
+  s.add_development_dependency 'mysql2'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'factory_girl_rails'


### PR DESCRIPTION
https://github.com/sasurai-usagi3/nippo-core/issues/17
特に`mysql2`に依存したシステムではないので、`mysql2`を`add_development_dependency`に修正しました